### PR TITLE
chore(ci): fix CodeQL schedule

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,14 +5,14 @@ on:
   pull_request:
     branches: [ main, master ]
   schedule:
-    - cron: "0 3 * * 0"
+    - cron: '0 3 * * 0'
 jobs:
   analyze:
     permissions:
       actions: read
       contents: read
       security-events: write
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v3


### PR DESCRIPTION
Fixes cron format to '0 3 * * 0' for weekly scans.